### PR TITLE
Optimizing Conversion to Compact Constraints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,11 @@
 Package: quadprogXT
 Title: Quadratic Programming with Absolute Value Constraints
-Version: 0.0.5
-Authors@R: person("Bob", "Harlow", email = "rharlow86@gmail.com",role = c("aut", "cre"))
+Version: 0.0.6
+Authors@R: c(
+  person("Bob", "Harlow", email = "rharlow86@gmail.com", role = c("aut", "cre")),
+  person("Brian", "Koch", email = "ctrlxctrlc@proton.me", role = "ctb"))
 Description: Extends the quadprog package to solve quadratic programs with
-    absolute value constraints and absolute values in the objective function.
+  absolute value constraints and absolute values in the objective function.
 Imports: quadprog
 License: GPL(>=2)
 Encoding: UTF-8

--- a/R/convertToCompactQP.R
+++ b/R/convertToCompactQP.R
@@ -18,7 +18,7 @@ convertToCompact <- function(A){
   mc <- max(cz)
 
   ## Throw an error if there are columns of all zeros.
-  if(any(cz) == 0) stop("Some columns of the constraint matrix are all zero.")
+  if(any(cz == 0)) stop("Some columns of the constraint matrix are all zero.")
 
   ## Build the output matrices.
   Amat <- matrix(data = 0, ncol = d[2L], nrow = mc)

--- a/R/convertToCompactQP.R
+++ b/R/convertToCompactQP.R
@@ -37,9 +37,8 @@ convertToCompact <- function(A){
   Aind[1L,] <- cz
 
   ## The entries in Aind (past the first row) correspond to the row index of
-  ## the non-zero elements in the input matrix. This expression below is a
-  ## bit nasty, however it's just a (much) faster version of: row(A)[ii].
-  Aind[-1L, ][io] <- (ii - 1L) %% d[1L] + 1L
+  ## the non-zero elements in the input matrix.
+  Aind[-1L, ][io] <- row(A)[ii]
 
   ## Write the matrices to the output list and return.
   out <- list(Amat = Amat, Aind = Aind)

--- a/R/convertToCompactQP.R
+++ b/R/convertToCompactQP.R
@@ -1,32 +1,47 @@
-#' 'Sparsify' constraint matrix
+#' Make a Constraint Matrix Compact
 #'
-#' @param Amat a constraint matrix as defined in solve.QP
-#' @return a list with two elements: Amat and Aind as necessary to be passed to solve.QP.compact
+#' @param A A constraint matrix as defined in solve.QP.
+#' @return A list containing the two elements to be passed to solve.QP.compact,
+#' each named accordingly.
 #' @seealso quadprog::solve.QP
 #' @seealso quadprog::solve.QP.compact
 #' @export
-convertToCompact <- function(Amat){
-    m_i <- colSums(abs(Amat) != 0)
-    maxmi <- max(m_i)
-    NC <- ncol(Amat)
-    Aind <- matrix(0, maxmi + 1, NC)
+convertToCompact <- function(A){
 
-    Aind[1, ] <- m_i
-    AmatSparse <- matrix(0, maxmi, NC)
-    
-    for(i in 1:NC){
-        
-        iNonZero <- which(Amat[,i] != 0)
-        nNonZero <- length(iNonZero)
-        if(!length(iNonZero)){
-            stop(sprintf("There are not any non zero elements in column %i", i))
-        }
-        
-        Aind[(1:nNonZero) + 1, i] <- iNonZero
-        AmatSparse[1:nNonZero ,i] <- Amat[iNonZero ,i]
-        
-    }
-    
-    list(Amat = AmatSparse, Aind = Aind)
+  ## Get the dimensions of the input and test what is non-zero.
+  d <- dim(A)
+  Az <- A != 0
+
+  ## Count the non-zero entries in each column and note the maximum. This will
+  ## be the number of rows in the output matrices (minus one for Aind).
+  cz <- colSums(Az)
+  mc <- max(cz)
+
+  ## Throw an error if there are columns of all zeros.
+  if(any(cz) == 0) stop("Some columns of the constraint matrix are all zero.")
+
+  ## Build the output matrices.
+  Amat <- matrix(data = 0, ncol = d[2L], nrow = mc)
+  Aind <- matrix(data = 0, ncol = d[2L], nrow = mc + 1L)
+
+  ## Note the indices for which the input matrix is non-zero as well as those
+  ## for which the output matrices will be non-zero. The latter is determined
+  ## by testing whether the row in the output matrix is less than the
+  ## count of non-zero entries in the corresponding column of A given by cz.
+  ii <- which(Az)
+  io <- which(row(Amat) <= cz[col(Amat)])
+
+  ## Write the non-zero entries of the input to Amat, and the non-zero counts
+  ## to the first row of Aind.
+  Amat[io] <- A[ii]
+  Aind[1L,] <- cz
+
+  ## The entries in Aind (past the first row) correspond to the row index of
+  ## the non-zero elements in the input matrix. This expression below is a
+  ## bit nasty, however it's just a (much) faster version of: row(A)[ii].
+  Aind[-1L, ][io] <- (ii - 1L) %% d[1L] + 1L
+
+  ## Write the matrices to the output list and return.
+  out <- list(Amat = Amat, Aind = Aind)
+  return(out)
 }
-

--- a/R/convertToCompactQP.R
+++ b/R/convertToCompactQP.R
@@ -6,11 +6,11 @@
 #' @seealso quadprog::solve.QP
 #' @seealso quadprog::solve.QP.compact
 #' @export
-convertToCompact <- function(A){
+convertToCompact <- function(Amat){
 
   ## Get the dimensions of the input and test what is non-zero.
-  d <- dim(A)
-  Az <- A != 0
+  d <- dim(Amat)
+  Az <- Amat != 0
 
   ## Count the non-zero entries in each column and note the maximum. This will
   ## be the number of rows in the output matrices (minus one for Aind).
@@ -21,28 +21,28 @@ convertToCompact <- function(A){
   if(any(cz == 0)) stop("Some columns of the constraint matrix are all zero.")
 
   ## Build the output matrices.
-  Amat <- matrix(data = 0, ncol = d[2L], nrow = mc)
-  Aind <- matrix(data = 0, ncol = d[2L], nrow = mc + 1L)
+  Am <- matrix(data = 0, ncol = d[2L], nrow = mc)
+  Ai <- matrix(data = 0, ncol = d[2L], nrow = mc + 1L)
 
   ## Note the indices for which the input matrix is non-zero as well as those
   ## for which the output matrices will be non-zero. The latter is determined
   ## by testing whether the row in the output matrix is less than the
   ## count of non-zero entries in the corresponding column of A given by cz.
   ii <- which(Az)
-  io <- which(row(Amat) <= cz[col(Amat)])
+  io <- which(row(Am) <= cz[col(Am)])
 
   ## Write the non-zero entries of the input to Amat, and the non-zero counts
   ## to the first row of Aind.
-  Amat[io] <- A[ii]
-  Aind[1L,] <- cz
+  Am[io] <- Amat[ii]
+  Ai[1L,] <- cz
 
   ## The entries in Aind (past the first row) correspond to the row index of
   ## the non-zero elements in the input matrix. The expression below is a bit
   ## nasty, however it's equivalent to row(A)[ii], just much faster when A is
   ## sparse.
-  Aind[-1L, ][io] <- (ii - 1L) %% d[1L] + 1L
+  Ai[-1L, ][io] <- (ii - 1L) %% d[1L] + 1L
 
   ## Write the matrices to the output list and return.
-  out <- list(Amat = Amat, Aind = Aind)
+  out <- list(Amat = Am, Aind = Ai)
   return(out)
 }

--- a/R/convertToCompactQP.R
+++ b/R/convertToCompactQP.R
@@ -37,8 +37,10 @@ convertToCompact <- function(A){
   Aind[1L,] <- cz
 
   ## The entries in Aind (past the first row) correspond to the row index of
-  ## the non-zero elements in the input matrix.
-  Aind[-1L, ][io] <- row(A)[ii]
+  ## the non-zero elements in the input matrix. The expression below is a bit
+  ## nasty, however it's equivalent to row(A)[ii], just much faster when A is
+  ## sparse.
+  Aind[-1L, ][io] <- (ii - 1L) %% d[1L] + 1L
 
   ## Write the matrices to the output list and return.
   out <- list(Amat = Amat, Aind = Aind)

--- a/R/convertToCompactQP.R
+++ b/R/convertToCompactQP.R
@@ -1,6 +1,6 @@
 #' Make a Constraint Matrix Compact
 #'
-#' @param A A constraint matrix as defined in solve.QP.
+#' @param Amat A constraint matrix as defined in solve.QP.
 #' @return A list containing the two elements to be passed to solve.QP.compact,
 #' each named accordingly.
 #' @seealso quadprog::solve.QP

--- a/inst/tinytest/test-convertToCompact.R
+++ b/inst/tinytest/test-convertToCompact.R
@@ -9,16 +9,16 @@ target <- list(Amat = AmatCompact, Aind = AindCompact)
 expect_equal(
   current = convertToCompact(Amat),
   target = target,
-  info = "Conversion to compact program yields same results as quadprog example"
+  info = "Conversion to compact program yields same results as quadprog example."
 )
 
 expect_error(
   current = convertToCompact(Amat * 0),
-  info = "Conversion to compact program fails when there is > 0 columns of all 0s"
+  info = "Conversion to compact program fails when there is > 0 columns of all 0s."
 )
 
 expect_equal(
   current = convertToCompact(AmatSparse)$Amat,
   target = target$AmatCompact,
-  info = "Conversion to compact program ignores unconstrained variables in Amat"
+  info = "Conversion to compact program ignores unconstrained variables in Amat."
 )

--- a/inst/tinytest/test-convertToCompact.R
+++ b/inst/tinytest/test-convertToCompact.R
@@ -19,6 +19,6 @@ expect_error(
 
 expect_equal(
   current = convertToCompact(AmatSparse)$Amat,
-  target = target$AmatCompact,
+  target = target$Amat,
   info = "Conversion to compact program ignores unconstrained variables in Amat."
 )

--- a/inst/tinytest/test-convertToCompact.R
+++ b/inst/tinytest/test-convertToCompact.R
@@ -1,15 +1,24 @@
 library(quadprogXT)
 
 Amat <- matrix(c(-4,-3,0,2,1,0,0,-2,1),3,3)
+AmatSparse <- rbind(Amat[1,], 0, 0, 0, 0, Amat[2:3,])
 AindCompact <- rbind(c(2,2,2),c(1,1,2),c(2,2,3))
 AmatCompact <- rbind(c(-4,2,-2),c(-3,1,1))
+target <- list(Amat = AmatCompact, Aind = AindCompact)
 
 expect_equal(
-    convertToCompact(Amat), list(Amat = AmatCompact, Aind = AindCompact),
-    info = "Conversion to compact program yields same results as quadprog example"
+  current = convertToCompact(Amat),
+  target = target,
+  info = "Conversion to compact program yields same results as quadprog example"
 )
 
 expect_error(
-    convertToCompact(Amat * 0),
-    info = "Conversion to compact program fails when there is > 0 columns of all 0s"
+  current = convertToCompact(Amat * 0),
+  info = "Conversion to compact program fails when there is > 0 columns of all 0s"
+)
+
+expect_equal(
+  current = convertToCompact(AmatSparse)$Amat,
+  target = target$AmatCompact,
+  info = "Conversion to compact program ignores unconstrained variables in Amat"
 )


### PR DESCRIPTION
I've removed the `for` loop from `convertToCompact`. This results in a considerable speed-up on the order of 10x for the matrices I tested.

I did not add any tests yet, and I'm a little confused by the second test. Why should it matter if `A` contains all-zero constraints? It doesn't really make sense why you'd want that as a user, as it doesn't alter the QP and it degrades performance, but it isn't necessarily erroneous either, right?